### PR TITLE
Update 'become' field to 'become_user' in xrdp create and populate .x…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Provision the VM
 
 	vagrant provision goku
 
-Repeat the above two commands for gohan, vageta and trunks.
+Repeat the above two commands for gohan, vegeta and trunks.
 
 ***...WARNING...***
 

--- a/roles/xrdp/tasks/main.yml
+++ b/roles/xrdp/tasks/main.yml
@@ -10,13 +10,13 @@
       . $HOME/.profile
 
 - name: Create the .xsesison file
-  become: "pentest"
+  become_user: "pentest"
   file:
     path: /home/pentest/.xsession
     state: touch
 
 - name: Populate the .xsession file
-  become: "pentest"
+  become_user: "pentest"
   blockinfile:
     dest: /home/pentest/.xsession
     marker: "# Vagrant setup .xsession"


### PR DESCRIPTION
…session tasks so that Ansible can switch to the 'pentest' user. The following error is generated with the existing config:

```
TASK [xrdp : Create the .xsesison file] ****************************************
fatal: [pentest]: FAILED! => {"msg": "the field 'become' has an invalid value (pentest), and could not be converted to an bool.The error was: The value 'pentest' is not a valid boolean.  Valid booleans include: 0, 1, 'true', '1', 'y', 'no', 'false', 'n', '0', 'off', 'f', 'on', 't', 'yes'"}
```