### PR TITLE
Fix: collides with a non-host network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,8 @@ Vagrant.configure("2") do |config|
       box.winrm.transport = :plaintext
       box.winrm.basic_auth_only = true
       box.vm.communicator = "winrm"
-      box.vm.network :private_network, ip: vm[:ip], netmask: "255.255.0.0", gateway: "192.168.56.1"
+      box.vm.network :private_network, ip: vm[:ip]
+      #, netmask: "255.255.0.0", gateway: "192.168.56.1"
 
       box.vm.provider "hyperv" do |hv|
         hv.vmname = "ccpt_#{vm[:name]}"


### PR DESCRIPTION
Those lines of code `netmask: "255.255.0.0", gateway: "192.168.56.1"` conflict with:

The specified host network collides with a non-hostonly network!
This will cause your specified IP to be inaccessible. Please change
the IP or name of your host only network so that it no longer matches that of
a bridged or non-hostonly network.

Bridged Network Address: '192.168.0.0'
Host-only Network 'en0: Wi-Fi (AirPort)': '192.168.0.0'